### PR TITLE
fix: suppress noisy Broken pipe error messages in RDP proxy

### DIFF
--- a/seth/main.py
+++ b/seth/main.py
@@ -62,7 +62,7 @@ class RDPProxy(threading.Thread):
                 os._exit(1)
             except (ConnectionResetError, OSError) as e:
                 if e.errno != 32:  # Ignorer Broken pipe
-                    print("Connexion fermée")
+                    print("Connection closed")
                 if "creds" in self.vars:
                     stop_attack()
 

--- a/seth/main.py
+++ b/seth/main.py
@@ -61,7 +61,7 @@ class RDPProxy(threading.Thread):
                 print("    MinProtocol = TLSv1.0")
                 os._exit(1)
             except (ConnectionResetError, OSError) as e:
-                if e.errno != 32:  # Ignorer Broken pipe
+                if e.errno != 32:  # Ignore Broken pipe
                     print("Connection closed")
                 if "creds" in self.vars:
                     stop_attack()

--- a/seth/main.py
+++ b/seth/main.py
@@ -61,7 +61,8 @@ class RDPProxy(threading.Thread):
                 print("    MinProtocol = TLSv1.0")
                 os._exit(1)
             except (ConnectionResetError, OSError) as e:
-                print("Connection lost (%s)" % str(e))
+                if e.errno != 32:  # Ignorer Broken pipe
+                    print("Connexion fermée")
                 if "creds" in self.vars:
                     stop_attack()
 


### PR DESCRIPTION
Before :
<img width="686" height="657" alt="Screenshot_2025-11-13_13-50-22" src="https://github.com/user-attachments/assets/78510311-6831-471d-b263-007463b2fdd2" />
After :
<img width="1051" height="778" alt="rdp_mitm" src="https://github.com/user-attachments/assets/dfd2e9c3-74d1-4966-b763-85f668be6976" />
